### PR TITLE
Improve repo filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Create your portfolio using this link: https://foliolab.vercel.app/
 - Auto deploy to Vercel/GitHub Pages with a single click
 - Update your portfolio as many times as you want
 - 100% free and open source, self-hosted or on Vercel
+- Automatically skips forked and archived repositories
 
 ## Tech Stack
 

--- a/server/lib/github.ts
+++ b/server/lib/github.ts
@@ -69,9 +69,12 @@ async function getUserRepositories(
     });
 
     const filteredRepos = data.filter((repo) => {
+      const lowerName = repo.name.toLowerCase();
       return (
-        !repo.name.toLowerCase().includes("-folio") &&
-        !repo.name.toLowerCase().includes("github.io") &&
+        !repo.fork &&
+        !repo.archived &&
+        !lowerName.includes("-folio") &&
+        !lowerName.includes("github.io") &&
         repo.name !== "foliolab-vercel"
       );
     });
@@ -131,9 +134,12 @@ async function getOrganizationRepositories(
     });
 
     const filteredRepos = data.filter((repo) => {
+      const lowerName = repo.name.toLowerCase();
       return (
-        !repo.name.toLowerCase().includes("-folio") &&
-        !repo.name.toLowerCase().includes("github.io") &&
+        !repo.fork &&
+        !repo.archived &&
+        !lowerName.includes("-folio") &&
+        !lowerName.includes("github.io") &&
         repo.name !== "foliolab-vercel"
       );
     });

--- a/tests/github-integration.test.ts
+++ b/tests/github-integration.test.ts
@@ -126,6 +126,21 @@ Content here.`;
       expect(filteredRepos.map(r => r.name)).toEqual(['my-project', 'valid-project']);
     });
 
+    it('should filter out forked and archived repositories', () => {
+      const mockRepos = [
+        { name: 'forked', id: 1, fork: true, archived: false },
+        { name: 'archived', id: 2, fork: false, archived: true },
+        { name: 'regular', id: 3, fork: false, archived: false },
+      ];
+
+      const filteredRepos = mockRepos.filter(repo => {
+        return !repo.fork && !repo.archived;
+      });
+
+      expect(filteredRepos).toHaveLength(1);
+      expect(filteredRepos[0].name).toBe('regular');
+    });
+
     it('should extract owner from GitHub URL', () => {
       const githubUrl = 'https://github.com/testuser/test-repo';
       const urlParts = githubUrl.split('/');


### PR DESCRIPTION
## Summary
- filter out forked and archived repositories when collecting repos
- note this behavior in the README
- cover filtering logic in tests

## Testing
- `npm run test:run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876e958b910832f9b43c35bf85fa025