### PR TITLE
Adopt the fleet Dependabot standard: grouped updates + guarded auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Supply-chain guard: only propose releases that are at least a week old.
+    # Security updates are not delayed by cooldown.
+    cooldown:
+      default-days: 7
+    # Majors are deliberately left ungrouped so they arrive as individual PRs
+    # and fail the auto-merge gate. Security updates are ungrouped too: a
+    # grouped PR reports its group name rather than a bump type, so grouping
+    # them would send every security fix to manual review, which is how this
+    # repo accumulated an eight-PR backlog in the first place.
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,83 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-merge everything except npm-ecosystem majors:
+      # - grouped PRs report the highest bump anywhere in the group (including
+      #   transitive lockfile updates), so trust our own minor-and-patch groups
+      # - GitHub-Actions majors are CI-validated and low blast radius
+      # An unrecognised or empty update-type is NOT eligible, so metadata
+      # failures leave the PR open rather than merging it. Each branch is a
+      # full if/case, never `test && var=true`: under `bash -e` a failing test
+      # as the last statement of a step fails the whole step.
+      - name: Decide eligibility
+        id: gate
+        env:
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          eligible=false
+          if [ "$ECOSYSTEM" = "github_actions" ]; then
+            eligible=true
+          fi
+          case "$GROUP" in
+            *minor-and-patch*) eligible=true ;;
+          esac
+          case "$UPDATE_TYPE" in
+            version-update:semver-minor|version-update:semver-patch) eligible=true ;;
+          esac
+          echo "ecosystem=$ECOSYSTEM group=$GROUP update-type=$UPDATE_TYPE eligible=$eligible"
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+
+      # No `gh pr review --approve`: it fails outright where the repo has
+      # "Allow GitHub Actions to create and approve pull requests" off, which
+      # aborted the step before the merge ever ran. Our rulesets require status
+      # checks, not reviews, and GitHub's own documented example does not
+      # approve either.
+      - name: Enable auto-merge for eligible updates
+        if: steps.gate.outputs.eligible == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if err=$(gh pr merge --auto --squash "$PR_URL" 2>&1); then
+            printf '%s\n' "$err"
+            exit 0
+          fi
+          printf '%s\n' "$err"
+          # GitHub refuses to arm auto-merge on a PR it currently considers
+          # mergeable, and this job finishes in seconds -- often before the
+          # required check runs exist. Do not merge directly here: "clean" at
+          # t+4s does not mean the checks passed.
+          case "$err" in
+            *"clean status"*|*"not mergeable"*|*"Auto merge is not allowed"*)
+              echo "::warning::auto-merge not armable yet; leaving PR open"
+              exit 0 ;;
+          esac
+          exit 1
+
+      - name: Flag ineligible updates for manual review
+        if: steps.gate.outputs.eligible != 'true' && github.event.action == 'opened'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Left open for manual review — auto-merge covers GitHub-Actions updates, our minor-and-patch groups, and patch/minor npm bumps."


### PR DESCRIPTION
## Why

This repo had **no `.github/dependabot.yml`**, so Dependabot version updates were off entirely and every PR came from repo-level security updates — ungrouped, no cooldown, no schedule. Eight piled up over three months behind a review requirement no bot could satisfy, alongside 37 open security alerts.

#55 made the CI gate real; the ruleset now requires the `gate` context and repo-level auto-merge is on. This is the part that actually drains the queue.

## What

Both files are ports of [gojiplus/py-canon](https://github.com/gojiplus/py-canon)'s template. Nothing in them depends on Python — the gate matches on the `*minor-and-patch*` glob in the group name and on semver bump type. `dependabot.yml` swaps `uv` for `npm` and renames the group; the workflow is verbatim apart from the wording of its manual-review comment.

**Policy:** weekly Monday, 7-day cooldown, grouped minor/patch for npm and GitHub Actions, auto-merged behind the required `gate` check. Majors are left ungrouped so they arrive individually and fail the gate.

**One deliberate departure from the template:** security updates are *not* grouped. A grouped PR reports its group name rather than a bump type, so grouping them would route every security fix to manual review — which is exactly how the current backlog accumulated. Ungrouped, each carries a parseable bump type, so minor/patch security fixes auto-merge and majors still get a human.

## Don't rewrite the gate logic

Its shape encodes three production incidents from the fleet:

- It is a **fail-closed allow-list**, not `update-type != semver-major` — the fail-open form merged whenever metadata came back empty or unparsed.
- **Every branch is a full `if`/`case`**, never `test && var=true`: under `bash -e`, a bare failing `test` as a step's last statement fails the whole step.
- It **never runs `gh pr review --approve`**, which hard-fails on repos where Actions may not approve PRs. foliolab is one of those — `can_approve_pull_request_reviews` is `false` — so the no-approve design is required here, not merely preferred. The ruleset requires status checks, not reviews.

`dependabot/fetch-metadata` stays SHA-pinned at v3.1.0.

## Follow-up

`on: pull_request` does not retro-fire, so the 8 existing PRs won't be evaluated by this workflow. They get drained separately with `py-canon/tools/dependabot_backfill.py`, which replays this same gate out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)